### PR TITLE
Add player comparison view and navigation

### DIFF
--- a/components/ComparePlayers.tsx
+++ b/components/ComparePlayers.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from "react";
+import FormContainer from "./ui/FormContainer";
+import Select from "./ui/Select";
+import { useFirebaseData } from "../hooks/useFirebaseData";
+import { safeGetItem, safeRemoveItem } from "../utils/storage";
+import { Player, ScoreEntry } from "../types/types";
+
+function calcStats(player: Player | undefined) {
+  if (!player) return { totalPlays: 0, bestScore: 0 };
+  let totalPlays = 0;
+  let bestScore = 0;
+  for (const scores of Object.values(player.scores || {})) {
+    totalPlays += scores.length;
+    for (const s of scores) if (s.score > bestScore) bestScore = s.score;
+  }
+  return { totalPlays, bestScore };
+}
+
+export default function ComparePlayers() {
+  const { players } = useFirebaseData();
+  const [player1Id, setPlayer1Id] = useState("");
+  const [player2Id, setPlayer2Id] = useState("");
+
+  useEffect(() => {
+    const prefill = safeGetItem("phof_compare_player1");
+    if (prefill && players.some((p) => p.id === prefill)) {
+      setPlayer1Id(prefill);
+      safeRemoveItem("phof_compare_player1");
+    }
+  }, [players]);
+
+  useEffect(() => {
+    if (!player1Id && players.length) setPlayer1Id(players[0].id);
+    if (!player2Id && players.length > 1) {
+      const p = players.find((x) => x.id !== player1Id);
+      setPlayer2Id(p ? p.id : players[0].id);
+    }
+  }, [players, player1Id, player2Id]);
+
+  const player1 = players.find((p) => p.id === player1Id);
+  const player2 = players.find((p) => p.id === player2Id);
+
+  const stats1 = useMemo(() => calcStats(player1), [player1]);
+  const stats2 = useMemo(() => calcStats(player2), [player2]);
+
+  const machineComparison = useMemo(() => {
+    if (!player1 || !player2) return [] as { name: string; p1Best: number; p2Best: number }[];
+    const names = Array.from(
+      new Set([...Object.keys(player1.scores || {}), ...Object.keys(player2.scores || {})]),
+    ).sort();
+    return names.map((name) => {
+      const p1Best = Math.max(...(player1.scores?.[name]?.map((s: ScoreEntry) => s.score) || [0]));
+      const p2Best = Math.max(...(player2.scores?.[name]?.map((s: ScoreEntry) => s.score) || [0]));
+      return { name, p1Best, p2Best };
+    });
+  }, [player1, player2]);
+
+  return (
+    <div className="space-y-4">
+      <FormContainer title="Compare Players">
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex-1">
+            <Select
+              label="Player 1"
+              value={player1Id}
+              onChange={(e) => setPlayer1Id(e.target.value)}
+              options={players.map((p) => ({ value: p.id, label: p.name }))}
+              placeholder="-- select player --"
+            />
+          </div>
+          <div className="flex-1">
+            <Select
+              label="Player 2"
+              value={player2Id}
+              onChange={(e) => setPlayer2Id(e.target.value)}
+              options={players.map((p) => ({ value: p.id, label: p.name }))}
+              placeholder="-- select player --"
+            />
+          </div>
+        </div>
+
+        {player1 && player2 ? (
+          <div className="space-y-8">
+            <div className="text-center text-xl md:text-2xl font-bold text-amber-400">
+              {player1.name} vs {player2.name}
+              <div className="text-sm text-gray-400">Who is the pinball wizard?</div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center">
+                <h3 className="text-lg font-semibold text-amber-300 mb-2">{player1.name}</h3>
+                <p>
+                  Total Plays: <span className="font-bold">{stats1.totalPlays}</span>
+                </p>
+                <p>
+                  Best Score: <span className="font-bold">{stats1.bestScore.toLocaleString()}</span>
+                </p>
+              </div>
+              <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center">
+                <h3 className="text-lg font-semibold text-amber-300 mb-2">{player2.name}</h3>
+                <p>
+                  Total Plays: <span className="font-bold">{stats2.totalPlays}</span>
+                </p>
+                <p>
+                  Best Score: <span className="font-bold">{stats2.bestScore.toLocaleString()}</span>
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <h4 className="text-lg font-semibold text-gray-200 mb-2">Machine Showdowns</h4>
+              {machineComparison.length === 0 ? (
+                <p className="text-gray-400">No machines in common yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {machineComparison.map((m) => (
+                    <div
+                      key={m.name}
+                      className="flex items-center gap-2 p-3 rounded-lg border border-gray-700 bg-gray-800 text-sm md:text-base"
+                    >
+                      <span className="flex-1 font-semibold text-amber-300">{m.name}</span>
+                      <span
+                        className={`flex-1 text-right ${m.p1Best >= m.p2Best ? "text-amber-400" : "text-gray-400"}`}
+                      >
+                        {m.p1Best ? m.p1Best.toLocaleString() : "—"}
+                      </span>
+                      <span className="mx-1 text-gray-500">vs</span>
+                      <span className={`flex-1 text-left ${m.p2Best >= m.p1Best ? "text-amber-400" : "text-gray-400"}`}>
+                        {m.p2Best ? m.p2Best.toLocaleString() : "—"}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="text-gray-400">Select two players to compare their pinball prowess.</p>
+        )}
+      </FormContainer>
+    </div>
+  );
+}

--- a/components/PlayerStats.tsx
+++ b/components/PlayerStats.tsx
@@ -307,6 +307,17 @@ export default function PlayerStats() {
                 <h4 className="text-sm font-semibold text-gray-200">Quick Actions</h4>
                 <div className="mt-3 flex flex-col gap-2">
                   <button
+                    className="px-3 py-2 rounded bg-blue-500 text-black font-semibold hover:bg-blue-400"
+                    onClick={() => {
+                      if (player) {
+                        safeSetItem("phof_compare_player1", player.id);
+                        window.location.hash = "comparePlayers";
+                      }
+                    }}
+                  >
+                    Compare Players
+                  </button>
+                  <button
                     className="px-3 py-2 rounded bg-amber-500 text-black font-semibold hover:bg-amber-400"
                     onClick={() => {
                       if (player) {

--- a/components/ui/NavBar.tsx
+++ b/components/ui/NavBar.tsx
@@ -52,7 +52,14 @@ export default function NavBar({ view, setView }: Props) {
   );
 
   const manageViews: View[] = ["manageScores", "managePlayers", "manageMachines", "manageDatabase"];
-  const scoresViews: View[] = ["addScore", "highScores", "highScoresWeekly", "allRecentScores", "playerStats"];
+  const scoresViews: View[] = [
+    "addScore",
+    "highScores",
+    "highScoresWeekly",
+    "allRecentScores",
+    "playerStats",
+    "comparePlayers",
+  ];
 
   // Shared overlay panel classes — note the new max-width
   const panelClasses =
@@ -109,6 +116,7 @@ export default function NavBar({ view, setView }: Props) {
               {btn("highScores", "trophy", "High Scores", scoresRef, "text-left")}
               {btn("highScoresWeekly", "bolt", "Weekly", scoresRef, "text-left")}
               {btn("playerStats", "user-astronaut", "Player Stats", scoresRef, "text-left")}
+              {btn("comparePlayers", "users", "Compare Players", scoresRef, "text-left")}
             </div>
           </details>
         </li>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import { View } from "../types/types";
 import NavBar from "@/components/ui/NavBar";
 import ManagePlayers from "@/components/ManagePlayers";
 import ManageMachines from "../components/ManageMachines";
+import ComparePlayers from "../components/ComparePlayers";
 import { useFirebaseData } from "../hooks/useFirebaseData";
 
 export default function IndexPage() {
@@ -32,6 +33,7 @@ export default function IndexPage() {
           "highScoresWeekly",
           "allRecentScores",
           "playerStats",
+          "comparePlayers",
           "manageDatabase",
         ].includes(hash)
       ) {
@@ -78,6 +80,7 @@ export default function IndexPage() {
       {view === "highScoresWeekly" && <HighScores initialViewMode="weekly" onNavigate={navigateToView} />}
       {view === "allRecentScores" && <AllRecentScores />}
       {view === "playerStats" && <PlayerStats />}
+      {view === "comparePlayers" && <ComparePlayers />}
       {view === "manageDatabase" && <ManageDatabase />}
     </div>
   );

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8,7 +8,8 @@ export type View =
   | "highScoresWeekly"
   | "allRecentScores"
   | "playerStats"
-  | "manageDatabase";
+  | "manageDatabase"
+  | "comparePlayers";
 
 export interface ScoreEntry {
   score: number;


### PR DESCRIPTION
## Summary
- add Compare Players page to pit two players' stats head-to-head
- link Compare Players from Player Stats quick actions and Scores navigation
- wire up new view type and routing

## Testing
- `npm run tsc`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689c93d8e2748332a0f737da2d2eb75c