### PR TITLE
Add player comparison feature with navigation links

### DIFF
--- a/components/ComparePlayers.tsx
+++ b/components/ComparePlayers.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from "react";
+import FormContainer from "./ui/FormContainer";
+import Select from "./ui/Select";
+import { useFirebaseData } from "../hooks/useFirebaseData";
+import { safeGetItem, safeRemoveItem } from "../utils/storage";
+
+export default function ComparePlayers() {
+  const { players } = useFirebaseData();
+  const [player1Id, setPlayer1Id] = useState("");
+  const [player2Id, setPlayer2Id] = useState("");
+
+  // Prefill first player from localStorage
+  useEffect(() => {
+    const stored = safeGetItem("phof_compare_player");
+    if (stored) {
+      setPlayer1Id(stored);
+      safeRemoveItem("phof_compare_player");
+    }
+  }, []);
+
+  // Set default selections once players load
+  useEffect(() => {
+    if (players.length) {
+      if (!player1Id) {
+        setPlayer1Id(players[0].id);
+      }
+      if (!player2Id) {
+        const second = players.find((p) => p.id !== player1Id)?.id || players[0].id;
+        setPlayer2Id(second);
+      }
+    }
+  }, [players, player1Id, player2Id]);
+
+  const player1 = players.find((p) => p.id === player1Id);
+  const player2 = players.find((p) => p.id === player2Id);
+
+  const comparison = useMemo(() => {
+    if (!player1 || !player2) return null;
+
+    const machineNames = Array.from(
+      new Set([...Object.keys(player1.scores || {}), ...Object.keys(player2.scores || {})]),
+    ).sort();
+
+    const machineStats = machineNames.map((mName) => {
+      const p1Scores = player1.scores?.[mName] || [];
+      const p2Scores = player2.scores?.[mName] || [];
+      const p1Best = p1Scores.reduce((mx, s) => (s.score > mx ? s.score : mx), 0);
+      const p2Best = p2Scores.reduce((mx, s) => (s.score > mx ? s.score : mx), 0);
+      return {
+        mName,
+        p1Best,
+        p2Best,
+        p1Plays: p1Scores.length,
+        p2Plays: p2Scores.length,
+      };
+    });
+
+    const totalPlays1 = Object.values(player1.scores || {}).reduce((sum, arr) => sum + arr.length, 0);
+    const totalPlays2 = Object.values(player2.scores || {}).reduce((sum, arr) => sum + arr.length, 0);
+    const bestScore1 = machineStats.reduce((mx, m) => (m.p1Best > mx ? m.p1Best : mx), 0);
+    const bestScore2 = machineStats.reduce((mx, m) => (m.p2Best > mx ? m.p2Best : mx), 0);
+    const machinesLed1 = machineStats.filter((m) => m.p1Best > m.p2Best).length;
+    const machinesLed2 = machineStats.filter((m) => m.p2Best > m.p1Best).length;
+
+    return {
+      machineStats,
+      totalPlays1,
+      totalPlays2,
+      bestScore1,
+      bestScore2,
+      machinesLed1,
+      machinesLed2,
+    };
+  }, [player1, player2]);
+
+  return (
+    <div className="space-y-4">
+      <FormContainer title="Compare Players">
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex-1">
+            <Select
+              value={player1Id}
+              onChange={(e) => setPlayer1Id(e.target.value)}
+              options={players.map((p) => ({ value: p.id, label: p.name }))}
+              label="Player One"
+            />
+          </div>
+          <div className="flex-1">
+            <Select
+              value={player2Id}
+              onChange={(e) => setPlayer2Id(e.target.value)}
+              options={players.map((p) => ({ value: p.id, label: p.name }))}
+              label="Player Two"
+            />
+          </div>
+        </div>
+
+        {!player1 || !player2 ? (
+          <p className="text-gray-400">Select two players to see who rules the arcade.</p>
+        ) : (
+          <div className="space-y-6">
+            {/* Light-hearted intro */}
+            <div className="text-center">
+              <h3 className="text-3xl font-bold text-amber-300 mb-1">{player1.name} vs {player2.name}</h3>
+              <p className="text-gray-400">Let the pinballs fly! 🎉</p>
+            </div>
+
+            {/* Summary stats */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center">
+                <h4 className="text-xl font-semibold text-amber-300 mb-2">{player1.name}</h4>
+                <div className="text-gray-200">Total Plays: {comparison?.totalPlays1 ?? 0}</div>
+                <div className="text-gray-200">Best Score: {comparison?.bestScore1.toLocaleString()}</div>
+                <div className="text-gray-200">Machines Led: {comparison?.machinesLed1}</div>
+              </div>
+              <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-center">
+                <h4 className="text-xl font-semibold text-amber-300 mb-2">{player2.name}</h4>
+                <div className="text-gray-200">Total Plays: {comparison?.totalPlays2 ?? 0}</div>
+                <div className="text-gray-200">Best Score: {comparison?.bestScore2.toLocaleString()}</div>
+                <div className="text-gray-200">Machines Led: {comparison?.machinesLed2}</div>
+              </div>
+            </div>
+
+            {/* Deep comparisons */}
+            <div>
+              <h4 className="text-lg font-bold text-blue-300 mb-3 text-center">Machine Showdowns</h4>
+              <div className="space-y-4">
+                {comparison?.machineStats.map((m) => (
+                  <div key={m.mName} className="rounded-lg border border-gray-700 bg-gray-900/50 p-4">
+                    <h5 className="font-semibold text-amber-300 mb-2">{m.mName}</h5>
+                    <div className="grid grid-cols-2 gap-4 text-sm">
+                      <div
+                        className={`p-2 rounded ${m.p1Best > m.p2Best ? "bg-amber-500 text-black" : "bg-gray-800 text-gray-200"}`}
+                      >
+                        <div className="font-semibold">{player1.name}</div>
+                        <div>Best: {m.p1Best ? m.p1Best.toLocaleString() : "—"}</div>
+                        <div>Plays: {m.p1Plays}</div>
+                      </div>
+                      <div
+                        className={`p-2 rounded ${m.p2Best > m.p1Best ? "bg-amber-500 text-black" : "bg-gray-800 text-gray-200"}`}
+                      >
+                        <div className="font-semibold">{player2.name}</div>
+                        <div>Best: {m.p2Best ? m.p2Best.toLocaleString() : "—"}</div>
+                        <div>Plays: {m.p2Plays}</div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </FormContainer>
+    </div>
+  );
+}
+

--- a/components/PlayerStats.tsx
+++ b/components/PlayerStats.tsx
@@ -317,6 +317,17 @@ export default function PlayerStats() {
                   >
                     Add Score for Player
                   </button>
+                  <button
+                    className="px-3 py-2 rounded bg-blue-500 text-black font-semibold hover:bg-blue-400"
+                    onClick={() => {
+                      if (player) {
+                        safeSetItem("phof_compare_player", player.id);
+                        window.location.hash = "comparePlayers";
+                      }
+                    }}
+                  >
+                    Compare with Another Player
+                  </button>
                 </div>
               </div>
             </div>

--- a/components/ui/NavBar.tsx
+++ b/components/ui/NavBar.tsx
@@ -52,7 +52,14 @@ export default function NavBar({ view, setView }: Props) {
   );
 
   const manageViews: View[] = ["manageScores", "managePlayers", "manageMachines", "manageDatabase"];
-  const scoresViews: View[] = ["addScore", "highScores", "highScoresWeekly", "allRecentScores", "playerStats"];
+  const scoresViews: View[] = [
+    "addScore",
+    "highScores",
+    "highScoresWeekly",
+    "allRecentScores",
+    "playerStats",
+    "comparePlayers",
+  ];
 
   // Shared overlay panel classes — note the new max-width
   const panelClasses =
@@ -109,6 +116,7 @@ export default function NavBar({ view, setView }: Props) {
               {btn("highScores", "trophy", "High Scores", scoresRef, "text-left")}
               {btn("highScoresWeekly", "bolt", "Weekly", scoresRef, "text-left")}
               {btn("playerStats", "user-astronaut", "Player Stats", scoresRef, "text-left")}
+              {btn("comparePlayers", "users", "Compare Players", scoresRef, "text-left")}
             </div>
           </details>
         </li>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import NavBar from "@/components/ui/NavBar";
 import ManagePlayers from "@/components/ManagePlayers";
 import ManageMachines from "../components/ManageMachines";
 import { useFirebaseData } from "../hooks/useFirebaseData";
+import ComparePlayers from "../components/ComparePlayers";
 
 export default function IndexPage() {
   const [view, setView] = useState<View>("home");
@@ -32,6 +33,7 @@ export default function IndexPage() {
           "highScoresWeekly",
           "allRecentScores",
           "playerStats",
+          "comparePlayers",
           "manageDatabase",
         ].includes(hash)
       ) {
@@ -78,6 +80,7 @@ export default function IndexPage() {
       {view === "highScoresWeekly" && <HighScores initialViewMode="weekly" onNavigate={navigateToView} />}
       {view === "allRecentScores" && <AllRecentScores />}
       {view === "playerStats" && <PlayerStats />}
+      {view === "comparePlayers" && <ComparePlayers />}
       {view === "manageDatabase" && <ManageDatabase />}
     </div>
   );

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8,6 +8,7 @@ export type View =
   | "highScoresWeekly"
   | "allRecentScores"
   | "playerStats"
+  | "comparePlayers"
   | "manageDatabase";
 
 export interface ScoreEntry {


### PR DESCRIPTION
## Summary
- add ComparePlayers page for head-to-head player stats with machine showdowns
- link Compare Players from PlayerStats quick actions and Scores nav
- update view routing and types for new Compare Players page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_689c93d8e2748332a0f737da2d2eb75c